### PR TITLE
Do not add new subscriptions during notifications

### DIFF
--- a/lib/garufa/subscriptions.rb
+++ b/lib/garufa/subscriptions.rb
@@ -5,13 +5,15 @@ module Garufa
   module Subscriptions
     extend self
 
+    @semaphore = Mutex.new
+
     def all
       subscriptions
     end
 
     def add(subscription)
       subs = subscriptions[subscription.channel] ||= Set.new
-      subs.add subscription
+      @semaphore.synchronize { subs.add subscription }
     end
 
     def remove(subscription)
@@ -29,15 +31,19 @@ module Garufa
     def notify_channel(channel, event, options)
       return if channel_size(channel).zero?
 
-      subscriptions[channel].each do |sub|
-        # Skip notifying if the same socket_id is provided
-        next if sub.socket_id == options[:socket_id]
+      subs = subscriptions[channel]
 
-        # Skip notifying the same member (probably from different tabs)
-        next if sub.presence_channel? and sub.channel_data == options[:data]
+      @semaphore.synchronize {
+        subs.each do |sub|
+          # Skip notifying if the same socket_id is provided
+          next if sub.socket_id == options[:socket_id]
 
-        sub.notify Message.channel_event(channel, event, options[:data])
-      end
+          # Skip notifying the same member (probably from different tabs)
+          next if sub.presence_channel? and sub.channel_data == options[:data]
+
+          sub.notify Message.channel_event(channel, event, options[:data])
+        end
+      }
     end
 
     def include?(subscription)


### PR DESCRIPTION
Synchronize access to subscriptions in order to avoid exception if a new
subscription is added to the set during an iteration.

Fixes #3
