### PR TITLE
Return status 200 instead of 202 when triggering events

### DIFF
--- a/lib/garufa/api/routes/events.rb
+++ b/lib/garufa/api/routes/events.rb
@@ -6,7 +6,6 @@ module Garufa
           r.is 'events' do
             handler = EventHandler.new
             handler.handle(read_body)
-            response.status = 202
             '{}'
           end
 

--- a/test/api.rb
+++ b/test/api.rb
@@ -67,7 +67,7 @@ module Garufa
         it 'should response 202 status code' do
           API::EventHandler.stub :new, handler do
             signed_post uri
-            last_response.status.must_equal 202
+            last_response.status.must_equal 200
           end
         end
 


### PR DESCRIPTION
Old api clients used a legacy endpoint for triggering events and expected 202 as response. If 202 was not returned, an exception was raised. New clients use a new endpoint and expect 200 as response.
