### PR TITLE
implement channel_stats for presence subscription_succeeded

### DIFF
--- a/lib/garufa/api/stats.rb
+++ b/lib/garufa/api/stats.rb
@@ -18,11 +18,11 @@ module Garufa
         end
       end
 
-      private
-
       def channel_size(channel)
         (subscriptions[channel] || []).size
       end
+
+      private
 
       def presence(channel)
         return unless channel.start_with?('presence-')

--- a/lib/garufa/subscriptions.rb
+++ b/lib/garufa/subscriptions.rb
@@ -1,5 +1,6 @@
 require 'set'
 require 'garufa/message'
+require 'garufa/api/stats'
 
 module Garufa
   module Subscriptions
@@ -53,6 +54,11 @@ module Garufa
 
     def channel_size(channel)
       (subscriptions[channel] || []).size
+    end
+
+    def channel_stats(channel)
+      stats = API::Stats.new(subscriptions)
+      stats.single_channel(channel)
     end
 
     private

--- a/lib/garufa/subscriptions.rb
+++ b/lib/garufa/subscriptions.rb
@@ -12,6 +12,10 @@ module Garufa
       subscriptions
     end
 
+    def stats
+      @stats ||= API::Stats.new(subscriptions)
+    end
+
     def add(subscription)
       subs = subscriptions[subscription.channel] ||= Set.new
       @semaphore.synchronize { subs.add subscription }
@@ -53,11 +57,10 @@ module Garufa
     end
 
     def channel_size(channel)
-      (subscriptions[channel] || []).size
+      stats.channel_size(channel)
     end
 
     def channel_stats(channel)
-      stats = API::Stats.new(subscriptions)
       stats.single_channel(channel)
     end
 


### PR DESCRIPTION
Implemented the channel_stats method so the presence in the subscription_succeeded is not null anymore, presence works now, @Juanmcuello would you be so kind to look over this? I don't know yet how to write performant ruby code and I'm not sure the way I implemented this bares a memory leak or similar.