### PR TITLE
Update ruby versions in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 rvm:
-  - 2.2.2
-  - 2.3.0
-  - 2.4.0
+  - 2.4.5
+  - 2.5.5
+  - 2.6.2
 before_install:
   - bundle init --gemspec=garufa.gemspec


### PR DESCRIPTION
- Remove 2.2, as it reached EOL.
- Remove 2.3, it will reach EOL in a few days.
- Add latest versions of 2.4, 2.5 and 2.6.